### PR TITLE
Add remote storage

### DIFF
--- a/app/assets/app/bootstrap.ts
+++ b/app/assets/app/bootstrap.ts
@@ -1,7 +1,16 @@
 import {bootstrap} from "angular2/platform/browser"
 import TodoAppComponent from "./app"
 import {LocalStorageTodoStore} from "./services/store"
+import {RemoteStorageTodoStore} from "./services/remoteStore"
 import {TodoStore} from "./services/todo.store"
 import {provide} from "angular2/core"
+import {HTTP_PROVIDERS} from "angular2/http"
 
-bootstrap(TodoAppComponent, [ provide(TodoStore, {useClass: LocalStorageTodoStore}) ])
+// To use local storage swap RemoteStorageTodoStore to be LocalStorageTodoStore
+bootstrap(
+    TodoAppComponent,
+    [
+        provide(TodoStore, {useClass: RemoteStorageTodoStore}),
+        HTTP_PROVIDERS
+    ]
+)

--- a/app/assets/app/services/remoteStore.ts
+++ b/app/assets/app/services/remoteStore.ts
@@ -14,17 +14,16 @@ export interface Todo {
 }
 @Injectable()
 export class RemoteStorageTodoStore implements TodoStore {
-    todos:Array<Todo>
-    private toDoUrl: String = "app/todo"
-    errorMessage: String
+    todos:Array<Todo> = []
+    private toDoUrl: string = "todos"
+    errorMessage: string
 
     constructor(private http: Http) {
+        let parent: RemoteStorageTodoStore = this
         this.getTodos()
             .subscribe(
-                todos => this.todos = todos,
-                error =>  this.errorMessage = <any>error)
-
-        this.todos = JSON.parse(localStorage.getItem("angular2-todos") || "[]")
+                todos => parent.todos = todos,
+                error =>  parent.errorMessage = <any>error)
     }
 
     getTodos (): Observable<Todo[]> {
@@ -35,7 +34,7 @@ export class RemoteStorageTodoStore implements TodoStore {
 
     private extractData(res: Response) {
         let body = res.json()
-        return body.data || { }
+        return body || []
     }
 
     private handleError (error: any) {

--- a/app/assets/app/services/remoteStore.ts
+++ b/app/assets/app/services/remoteStore.ts
@@ -1,0 +1,97 @@
+import {Injectable} from "angular2/core"
+import {TodoStore} from "./todo.store"
+import { Http, Response } from "angular2/http"
+import { Observable } from "rxjs/Observable"
+import { Observer } from "rxjs/Observer"
+
+import "rxjs/add/operator/map"
+import "rxjs/add/operator/catch"
+
+export interface Todo {
+    completed: Boolean
+    editing: Boolean
+    title: String
+}
+@Injectable()
+export class RemoteStorageTodoStore implements TodoStore {
+    todos:Array<Todo>
+    private toDoUrl: String = "app/todo"
+    errorMessage: String
+
+    constructor(private http: Http) {
+        this.getTodos()
+            .subscribe(
+                todos => this.todos = todos,
+                error =>  this.errorMessage = <any>error)
+
+        this.todos = JSON.parse(localStorage.getItem("angular2-todos") || "[]")
+    }
+
+    getTodos (): Observable<Todo[]> {
+        return this.http.get(this.toDoUrl)
+            .map(this.extractData)
+            .catch(this.handleError)
+    }
+
+    private extractData(res: Response) {
+        let body = res.json()
+        return body.data || { }
+    }
+
+    private handleError (error: any) {
+        // In a real world app, we might use a remote logging infrastructure
+        // We'd also dig deeper into the error to get a better message
+        let errMsg = (error.message) ? error.message :
+            error.status ? `${error.status} - ${error.statusText}` : "Server error"
+        console.error(errMsg) // log to console instead
+        return Observable.throw(errMsg)
+    }
+
+    private updateStore() {
+        localStorage.setItem("angular2-todos", JSON.stringify(this.todos))
+    }
+
+    private getWithCompleted(completed:Boolean) {
+        return this.todos.filter((todo:Todo) => todo.completed === completed)
+    }
+
+    allCompleted() {
+        return this.todos.length === this.getCompleted().length
+    }
+
+    setAllTo(completed:Boolean) {
+        this.todos.forEach((t:Todo) => t.completed = completed)
+        this.updateStore()
+    }
+
+    removeCompleted() {
+        this.todos = this.getWithCompleted(false)
+        this.updateStore()
+    }
+
+    getRemaining() {
+        return this.getWithCompleted(false)
+    }
+
+    getCompleted() {
+        return this.getWithCompleted(true)
+    }
+
+    toggleCompletion(todo:Todo) {
+        todo.completed = !todo.completed
+        this.updateStore()
+    }
+
+    remove(todo:Todo) {
+        this.todos.splice(this.todos.indexOf(todo), 1)
+        this.updateStore()
+    }
+
+    add(title:String) {
+        const todo = <Todo>{
+            title: title
+        }
+        this.todos.push(todo)
+        this.updateStore()
+    }
+}

--- a/app/assets/app/services/remoteStore.ts
+++ b/app/assets/app/services/remoteStore.ts
@@ -38,8 +38,6 @@ export class RemoteStorageTodoStore implements TodoStore {
     }
 
     private handleError (error: any) {
-        // In a real world app, we might use a remote logging infrastructure
-        // We'd also dig deeper into the error to get a better message
         let errMsg = (error.message) ? error.message :
             error.status ? `${error.status} - ${error.statusText}` : "Server error"
         console.error(errMsg) // log to console instead
@@ -47,7 +45,9 @@ export class RemoteStorageTodoStore implements TodoStore {
     }
 
     private updateStore() {
-        localStorage.setItem("angular2-todos", JSON.stringify(this.todos))
+        return this.http.post(this.toDoUrl, JSON.stringify(this.todos))
+            .map(this.extractData)
+            .catch(this.handleError)
     }
 
     private getWithCompleted(completed:Boolean) {

--- a/app/assets/app/services/remoteStore.ts
+++ b/app/assets/app/services/remoteStore.ts
@@ -4,6 +4,8 @@ import { Http, Response } from "angular2/http"
 import { Observable } from "rxjs/Observable"
 import { Observer } from "rxjs/Observer"
 
+import { Headers, RequestOptions } from "angular2/http"
+
 import "rxjs/add/operator/map"
 import "rxjs/add/operator/catch"
 
@@ -45,9 +47,13 @@ export class RemoteStorageTodoStore implements TodoStore {
     }
 
     private updateStore() {
-        return this.http.post(this.toDoUrl, JSON.stringify(this.todos))
+        let headers = new Headers({ "Content-Type": "application/json" })
+        let options = new RequestOptions({ headers: headers })
+        return this.http.post(this.toDoUrl, JSON.stringify(this.todos), options)
             .map(this.extractData)
             .catch(this.handleError)
+            .subscribe(todos => alert("success"),
+                       error =>  alert("fail"))
     }
 
     private getWithCompleted(completed:Boolean) {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import play.api._
+import models.Todo
 import play.api.mvc._
 
 class Application extends Controller {
@@ -35,6 +35,16 @@ class Application extends Controller {
         |     "title": "Three"
         |   }
         | ] """.stripMargin)
+  }
+
+  def createTodo() = Action { request =>
+      val json = request.body.asJson.get
+      val todos = json.as[Seq[Todo]]
+    Ok("""[{
+         |     "completed": false,
+         |     "editing": false,
+         |     "title": "One"
+         |   }]""".stripMargin)
   }
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,7 +1,8 @@
 package controllers
 
 import models.Todo
-import play.api.mvc._
+import play.api.libs.json.{Json, _}
+import play.api.mvc.{Action, _}
 
 class Application extends Controller {
 
@@ -14,37 +15,27 @@ class Application extends Controller {
     Ok(views.html.index1())
   }
 
-  def todos = Action {
+  val t = List(Todo("Foo"), Todo("Bar"), Todo("Frog"))
 
-    Ok(
-      """
-        | [
-        |   {
-        |     "completed": false,
-        |     "editing": false,
-        |     "title": "One"
-        |   },
-        |   {
-        |     "completed": false,
-        |     "editing": false,
-        |     "title": "Two"
-        |   },
-        |   {
-        |     "completed": false,
-        |     "editing": false,
-        |     "title": "Three"
-        |   }
-        | ] """.stripMargin)
+  def todos = Action {
+    Ok(Json.toJson(t))
   }
 
-  def createTodo() = Action { request =>
-      val json = request.body.asJson.get
-      val todos = json.as[Seq[Todo]]
-    Ok("""[{
-         |     "completed": false,
-         |     "editing": false,
-         |     "title": "One"
-         |   }]""".stripMargin)
+  /**
+    * This is not the most efficient way of doing things. In a real environment
+    * one wouldn't update the entire list every time. This should be taken as an
+    * example of how to write a route but not as an example of good architecture
+   */
+  def updateTodos() = Action { request =>
+    val body: AnyContent = request.body
+    val jsonBody: Option[JsValue] = body.asJson
+
+    // Expecting json body
+    jsonBody.map { json =>
+      Ok(Json.toJson(t))
+    }.getOrElse {
+      BadRequest("Expecting application/json request body")
+    }
   }
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -14,4 +14,27 @@ class Application extends Controller {
     Ok(views.html.index1())
   }
 
+  def todos = Action {
+
+    Ok(
+      """
+        | [
+        |   {
+        |     "completed": false,
+        |     "editing": false,
+        |     "title": "One"
+        |   },
+        |   {
+        |     "completed": false,
+        |     "editing": false,
+        |     "title": "Two"
+        |   },
+        |   {
+        |     "completed": false,
+        |     "editing": false,
+        |     "title": "Three"
+        |   }
+        | ] """.stripMargin)
+  }
+
 }

--- a/app/models/Todo.scala
+++ b/app/models/Todo.scala
@@ -2,8 +2,12 @@ package models
 
 import play.api.libs.json.Json
 
-case class Todo(title: String, completed: Boolean = false, editing: Boolean = false)
 
+
+case class Todo(title: String, completed: Boolean = false, editing: Boolean = false)
 object Todo {
-  implicit val formats = Json.reads[Todo]
+  implicit val reads = Json.reads[Todo]
+  implicit val writes = Json.writes[Todo]
+
+//  implicit val seqTodoWrites = Json.writes[Seq[Todo]]
 }

--- a/app/models/Todo.scala
+++ b/app/models/Todo.scala
@@ -4,10 +4,8 @@ import play.api.libs.json.Json
 
 
 
-case class Todo(title: String, completed: Boolean = false, editing: Boolean = false)
+case class Todo(title: String, completed: Option[Boolean] = None, editing: Option[Boolean] = None)
 object Todo {
   implicit val reads = Json.reads[Todo]
   implicit val writes = Json.writes[Todo]
-
-//  implicit val seqTodoWrites = Json.writes[Seq[Todo]]
 }

--- a/app/models/Todo.scala
+++ b/app/models/Todo.scala
@@ -1,0 +1,9 @@
+package models
+
+import play.api.libs.json.Json
+
+case class Todo(title: String, completed: Boolean = false, editing: Boolean = false)
+
+object Todo {
+  implicit val formats = Json.reads[Todo]
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -12,6 +12,7 @@
     <script src='@routes.Assets.versioned("lib/typescript/lib/typescript.js")'></script>
     <script src='@routes.Assets.versioned("lib/rxjs/bundles/Rx.js")'></script>
     <script src='@routes.Assets.versioned("lib/angular2/bundles/angular2.dev.js")'></script>
+    <script src='@routes.Assets.versioned("lib/angular2/bundles/http.dev.js")'></script>
 
     </head>
     <body>

--- a/app/views/index1.scala.html
+++ b/app/views/index1.scala.html
@@ -12,6 +12,7 @@
         <script src='@routes.Assets.versioned("lib/systemjs/dist/system.js")'></script>
         <script src='@routes.Assets.versioned("lib/rxjs/bundles/Rx.js")'></script>
         <script src='@routes.Assets.versioned("lib/angular2/bundles/angular2.dev.js")'></script>
+        <script src='@routes.Assets.versioned("lib/angular2/bundles/http.dev.js")'></script>
         <script>    @* our app is downloaded as individual javascript files by SystemJs
                      after compilation by sbt-typescript*@
                 System.config({

--- a/app/views/index2.scala.html
+++ b/app/views/index2.scala.html
@@ -10,6 +10,7 @@
         <script src='@routes.Assets.versioned("lib/systemjs/dist/system.js")'></script>
         <script src='@routes.Assets.versioned("lib/rxjs/bundles/Rx.js")'></script>
         <script src='@routes.Assets.versioned("lib/angular2/bundles/angular2.dev.js")'></script>
+        <script src='@routes.Assets.versioned("lib/angular2/bundles/http.dev.js")'></script>
 
         @* if we provide the jvm option -DtsCompileMode=stage to our sbt task our
            typescript app is compiled to one JS file including the ES6 libraries that our app depends on *@

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,10 @@ libraryDependencies ++= Seq(
   "org.webjars.npm" % "codelyzer" % "0.0.19",
 
   //test
-  "org.webjars.npm" % "jasmine" % "2.4.1" % "test"
+  "org.webjars.npm" % "jasmine" % "2.4.1" % "test",
+
+  //scala stuff
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )
 dependencyOverrides ++= Set(
   "org.webjars.npm" % "minimatch" % "3.0.0",

--- a/conf/routes
+++ b/conf/routes
@@ -4,6 +4,7 @@
 
 # Home page
 GET     /                           controllers.Application.index
+GET     /todos                      controllers.Application.todos
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 # Home page
 GET     /                           controllers.Application.index
 GET     /todos                      controllers.Application.todos
-POST    /todos                      controllers.Application.createTodo
+POST    /todos                      controllers.Application.updateTodos
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@
 # Home page
 GET     /                           controllers.Application.index
 GET     /todos                      controllers.Application.todos
+POST    /todos                      controllers.Application.createTodo
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/test/models/TodoTest.scala
+++ b/test/models/TodoTest.scala
@@ -1,0 +1,11 @@
+package models
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TodoTest extends FlatSpec with Matchers {
+
+  "The application" should "have unit tests" in {
+    "Foobar" should be ("Foobar")
+  }
+
+}


### PR DESCRIPTION
The existing implementation uses local storage in the browser, but this version adds a new implementation of the TodoStore interface "RemoteTodoStore". This is a very basic implementation that calls the Scala backend to either GET or PUT the current list

Please bear in mind that this is purely for the purposes of being a stub project to speed up initial development and I would not suggest structuing the front end and server in this fashion in a real application. The work done does however give examples of how to:

1) Add scala routes
2) Add Models
3) Add json serialisation of models
4) Calling http endpoints from Angular 2
5) How to test scala code

This PR sets the default storage to be Remote but it can easily be flicked back to be Local by modifying the bootstrap.ts file. 
