### PR TITLE
When adding a new item, the counter is not updated.

### DIFF
--- a/app/assets/app/services/store.ts
+++ b/app/assets/app/services/store.ts
@@ -57,6 +57,8 @@ export class LocalStorageTodoStore implements TodoStore {
 
     add(title:String) {
         const todo = <Todo>{
+            completed: false,
+            editing: false,
             title: title
         }
         this.todos.push(todo)


### PR DESCRIPTION
Setting completed and editing to false when adding a new item, so the counter works.
